### PR TITLE
Show latency measurements for when doing requests

### DIFF
--- a/cmd/exam.go
+++ b/cmd/exam.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"text/tabwriter"
-	"time"
 
 	utils "github.com/JoseThen/checkup/utils"
 	"github.com/spf13/cobra"
@@ -25,13 +23,10 @@ var examCmd = &cobra.Command{
 		auth, _ := cmd.Flags().GetBool("auth")
 		exam := utils.ReadExam(file)
 		exitCode := 0
-		// Setup http Client
-		var httpClient = &http.Client{
-			Timeout: time.Second * 10,
-		}
+
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t", "Endpoint", "Code", "Result", "Pass")
-		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t", "--------", "----", "------", "----")
+		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t%s\t", "Endpoint", "Code", "Result", "Latency", "Pass")
+		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t%s\t", "--------", "----", "------", "-------", "----")
 		for _, test := range exam.Tests {
 			for _, path := range test.Paths {
 				// Setup check Request with above variables
@@ -42,8 +37,9 @@ var examCmd = &cobra.Command{
 					Auth:     auth,
 				}
 				checkup := utils.Checkup(*checkRequest)
-				fmt.Fprintf(w, "\n %s\t%d\t%d\t%v\t", checkup.Endpoint, checkup.Code, checkup.Result, checkup.Pass)
-				if checkup.Pass == false {
+				httpClient.CloseIdleConnections()
+				fmt.Fprintf(w, "\n %s\t%d\t%d\t%dms\t%v\t", checkup.Endpoint, checkup.Code, checkup.Result, checkup.Lantency.Milliseconds(), checkup.Pass)
+				if !checkup.Pass {
 					exitCode = 3
 				}
 			}

--- a/cmd/listen.go
+++ b/cmd/listen.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"text/tabwriter"
-	"time"
 
 	utils "github.com/JoseThen/checkup/utils"
 	"github.com/spf13/cobra"
@@ -27,10 +25,7 @@ var listenCmd = &cobra.Command{
 		code, _ := cmd.Flags().GetInt("code")
 		auth, _ := cmd.Flags().GetBool("auth")
 		endpoint, _ := cmd.Flags().GetString("endpoint")
-		// Setting up http Client
-		var httpClient = &http.Client{
-			Timeout: time.Second * 10,
-		}
+
 		// Setup check Request with above variables
 		checkRequest := &utils.CheckupRequest{
 			Client:   httpClient,
@@ -38,12 +33,12 @@ var listenCmd = &cobra.Command{
 			Endpoint: endpoint,
 			Auth:     auth,
 		}
-		// checkup := utils.Checkup(httpClient, code, endpoint, auth)
 		checkup := utils.Checkup(*checkRequest)
+		httpClient.CloseIdleConnections()
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t", "Endpoint", "Code", "Result", "Pass")
-		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t", "--------", "----", "------", "----")
-		fmt.Fprintf(w, "\n %s\t%d\t%d\t%v\t", checkup.Endpoint, checkup.Code, checkup.Result, checkup.Pass)
+		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t%s\t", "Endpoint", "Code", "Result", "Latency", "Pass")
+		fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t%s\t", "--------", "----", "------", "-------", "----")
+		fmt.Fprintf(w, "\n %s\t%d\t%d\t%dms\t%v\t", checkup.Endpoint, checkup.Code, checkup.Result, checkup.Lantency.Milliseconds(), checkup.Pass)
 		w.Flush()
 		fmt.Println()
 		if checkup.Pass {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -20,6 +22,11 @@ var rootCmd = &cobra.Command{
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Setup http Client
+var httpClient = &http.Client{
+	Timeout: time.Second * 10,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 .PHONY: build run compile build-linux build-windows build-darwin test
 
-VERSION ?= 0.4.0
+VERSION ?= 0.5.0
 NAME ?= "checkup"
 
 test:

--- a/utils/ReadExam.go
+++ b/utils/ReadExam.go
@@ -26,7 +26,7 @@ func ReadExam(file string) ExamFile {
 	examFile, err := ioutil.ReadFile(file)
 	ErrorCheck(err)
 	extension := filepath.Ext(strings.TrimSpace(file))
-	err = fmt.Errorf("Wrong Extension: %v", extension)
+	err = fmt.Errorf("wrong Extension: %v", extension)
 	if extension == ".yaml" || extension == ".yml" {
 		err = yaml.Unmarshal(examFile, &exam)
 	}

--- a/utils/checkup.go
+++ b/utils/checkup.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"os"
+	"time"
 )
 
 // CheckupRequest ... Struct holding all data needed for a checkup
@@ -19,6 +20,7 @@ type CheckupResults struct {
 	Endpoint string
 	Code     int
 	Result   int
+	Lantency time.Duration
 	Pass     bool
 }
 
@@ -37,16 +39,18 @@ func Checkup(healthForm CheckupRequest) CheckupResults {
 		healthForm.Client.CheckRedirect = addAuthOnRedirect
 	}
 
+	start := time.Now()
 	resp, err := healthForm.Client.Do(request)
 	if err != nil {
 		ErrorCheck(err)
 	}
+	end := time.Since(start)
 	defer resp.Body.Close()
-
 	results := CheckupResults{
 		Endpoint: healthForm.Endpoint,
 		Code:     healthForm.Code,
 		Result:   resp.StatusCode,
+		Lantency: end,
 		Pass:     resp.StatusCode == healthForm.Code,
 	}
 


### PR DESCRIPTION
output looks like the following: 
```bash
 Endpoint                         Code Result Latency Pass 
 --------                         ---- ------ ------- ---- 
 https://duckduckgo.com/farm      200  200    706ms   true 
 https://duckduckgo.com/something 200  200    166ms   true 
 https://duckduckgo.com/else      200  200    410ms   true 
 https://duckduckgo.com/pie       200  200    191ms   true 
 https://duckduckgo.com/apple     200  200    308ms   true 
 https://duckduckgo.com/pear      200  200    193ms   true 
 https://duckduckgo.com/banana    200  200    187ms   true
```